### PR TITLE
Use std::lock_guard instead of naked mutex locking/unlocking.

### DIFF
--- a/src/pybind/tensor_buffer.cpp
+++ b/src/pybind/tensor_buffer.cpp
@@ -21,7 +21,7 @@ TensorBuffer::TensorBuffer(torch::IntArrayRef size, std::string device)
 
 void TensorBuffer::set_buffer(uint16_t data[], int numbytes) {
   const auto length = numbytes >> 1;
-  buffer_lock.lock();
+  const std::lock_guard lock{buffer_lock};
   bool *array = (bool *)buffer1->data_ptr();
   for (int i = 0; i < length; i = i + 2) {
     // Decode x, y
@@ -29,23 +29,22 @@ void TensorBuffer::set_buffer(uint16_t data[], int numbytes) {
     const uint16_t x_coord = data[i + 1] & 0x7FFF;
     *(array + shape[1] * x_coord + y_coord) = true;
   }
-  buffer_lock.unlock();
 }
 
 void TensorBuffer::set_vector(std::vector<AEDAT::PolarityEvent> events) {
-  buffer_lock.lock();
+  const std::lock_guard lock{buffer_lock};
   bool *array = (bool *)buffer1->data_ptr();
   for (auto event : events) {
     *(array + shape[1] * event.x + event.y) = true;
   }
-  buffer_lock.unlock();
 }
 
 at::Tensor TensorBuffer::read() {
   // Swap out old pointer
-  buffer_lock.lock();
-  buffer1.swap(buffer2);
-  buffer_lock.unlock();
+  {
+    const std::lock_guard lock{buffer_lock};
+    buffer1.swap(buffer2);
+  }
   // Copy and clean
   auto copy = buffer2->to(options_copy, true, true);
   buffer2->index_put_({torch::indexing::Slice()}, false);


### PR DESCRIPTION
To ensure that the mutex is unlocked when leaving the scope, even if an exception would be thrown, use a std::lock_guard.