### PR TITLE
Fixed sleep time for real-time file input.

### DIFF
--- a/src/input/file.cpp
+++ b/src/input/file.cpp
@@ -25,8 +25,7 @@ Generator<AEDAT::PolarityEvent> file_event_generator(const std::string filename,
       const int64_t file_diff = event.timestamp - time_start_us;
       const int64_t time_offset = file_diff - time_diff;
       if (time_offset > 1000) {
-        const auto sleep_time = std::min((int64_t)1000, time_offset);
-        std::this_thread::sleep_for(std::chrono::microseconds(sleep_time));
+        std::this_thread::sleep_for(std::chrono::microseconds(time_offset));
       }
     }
     co_yield event;


### PR DESCRIPTION
```
if (time_offset > 1000) {
        const auto sleep_time = std::min((int64_t)1000, time_offset);
}
```
will always set sleep_time to 1000. Thus, before the proposed change, the code will either not sleep at all or sleep for 1000 microseconds, never longer.

Instead, sleep for the actual difference between the event timestamp and the clock time (as long as the difference is > 1000 microseconds).