### PR TITLE
Fix build issues.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
     ext_modules=[
         cpp_extension.CppExtension(
             name="aestream",
-            headers=cpp_headers,
             sources=cpp_sources,
             extra_compile_args=[
                 "-O3",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT flatbuffers)
     FetchContent_Declare(
         flatbuffers
         GIT_REPOSITORY  https://github.com/google/flatbuffers.git
-        GIT_TAG         v2.0.0
+        GIT_TAG         v2.0.6
     )
 
     FetchContent_MakeAvailable(flatbuffers)
@@ -17,10 +17,14 @@ endif()
 find_path(LZ4_INCLUDE_DIR NAMES	lz4.h)
 find_library(LZ4_LIBRARY NAMES lz4 REQUIRED)
 
+# OpenCV
+find_package (OpenCV 4.0.0 REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+
 # AEDAT4 processing
 add_library(aedat4 SHARED aedat.hpp aedat4.hpp generator.hpp)
 include_directories(aedat4 PRIVATE ${LZ4_INCLUDE_DIR} ${flatbuffers_SOURCE_DIR}/include/)
-target_link_libraries(aedat4 PRIVATE ${LZ4_LIBRARY} ${flatbuffers})
+target_link_libraries(aedat4 PRIVATE ${LZ4_LIBRARY} flatbuffers)
 set_target_properties(aedat4 PROPERTIES LINKER_LANGUAGE CXX)
 
 # Add subdirectories


### PR DESCRIPTION
1. Remove "headers" option from setup.py to fix distutils warning "Unknown Extension options: 'headers'":

```
/usr/lib/python3.10/distutils/extension.py:132: UserWarning: Unknown Extension options: 'headers'
  warnings.warn(msg)
```

2. Update version of flatbuffers to fetch from Github to match the version of flatbuffers that was used to generate `src/trigger_generated.h`, thus solving the following compile error:
```
/home/emijan/norse/aestream/src/trigger_generated.h:13:44: error: static assertion failed: Non-compatible flatbuffers version included
   13 |               FLATBUFFERS_VERSION_REVISION == 6,
```

3. Add section for OpenCV to src/CMakeLists.txt in order to add OpenCV to compiler include directories.

4. Use "flatbuffers" instead of "${flatbuffers}" to fix the following CMake error stating that flatbuffers variable is not set:
```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
flatbuffers
    linked by target "aedat4" in directory /home/emijan/norse/aestream/src

```
