### PR TITLE
Re-introduced file reading with nanobind primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ AEStream is usable both as a command-line binary or Python tool.
 
 Contributions to support AEStream on additional platforms are always welcome.
 
-## Usage (Python)
+## Usage: read event-address files in Python
 
-The Python API exposes two classes for reading DVS data sources into PyTorch tensors: `USBInput` and `UDPInput`.
+AEStream can process fixed input sources like files like so:
+
+```python
+FileInput("file", (640, 480)).load()
+```
+
+## Usage: stream real-time data in Python
+AEStream also supports streaming data in real-time *without strict guarantees on orders*. 
+This is particularly useful in real-time scenarios, for instance when operating with `USBInput` or `UDPInput`
 
 ```python
 # Stream events from a DVS camera over USB

--- a/aestream/__init__.py
+++ b/aestream/__init__.py
@@ -11,11 +11,12 @@ except ImportError:
     logging.debug("Failed to import Torch: AEStream is running in Numpy mode")
     del logging
 
+from aestream.aestream_ext import Event
 from aestream._input import FileInput, UDPInput
 
 modules = []
 try:
-    from aestream_ext import USBInput
+    from aestream.aestream_ext import USBInput
 
     modules.append("USBInput")
 except ImportError:
@@ -24,6 +25,6 @@ except ImportError:
     logging.debug("Failed to import AEStream USB Input")
     del logging
 
-__all__ = ["FileInput", "UDPInput"] + modules
+__all__ = ["Event", "FileInput", "UDPInput"] + modules
 
 del modules

--- a/aestream/__init__.py
+++ b/aestream/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
     logging.debug("Failed to import Torch: AEStream is running in Numpy mode")
     del logging
 
+# Import AEStream modules
 from aestream.aestream_ext import Event
 from aestream._input import FileInput, UDPInput
 

--- a/aestream/_input.py
+++ b/aestream/_input.py
@@ -1,5 +1,14 @@
 from aestream import aestream_ext as ext
 
+# Set Numpy Event dtype
+try:
+    import numpy as np
+    event_dtype = np.dtype(("=V", 13))
+    NUMPY_EVENT_DTYPE = np.dtype((event_dtype, {"timestamp": (np.int64, 0), "x": (np.int16, 8), "y": (np.int16, 10), "polarity": (np.byte, 12)}))
+
+except ImportError as e:
+    raise ImportError("Numpy is required but could not be imported", e)
+
 try:
     import torch
     USE_TORCH = True
@@ -7,6 +16,11 @@ except ImportError:
     USE_TORCH = False
 
 class FileInput(ext.FileInput):
+
+    def load(self):
+        buffer = self.load_all()
+        return np.frombuffer(buffer.data, NUMPY_EVENT_DTYPE)
+
     def read(self):
         t = self.read_buffer()
         if USE_TORCH:

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,9 +55,17 @@ AEStream is usable both as a command-line binary or Python tool.
 
 Contributions to support AEStream on additional platforms are always welcome.
 
-## Usage (Python)
+## Usage: read event-address files in Python
 
-The Python API exposes two classes for reading DVS data sources into PyTorch tensors: `USBInput` and `UDPInput`.
+AEStream can process fixed input sources like files like so:
+
+```python
+FileInput("file", (640, 480)).load()
+```
+
+## Usage: stream real-time data in Python
+AEStream also supports streaming data in real-time *without strict guarantees on orders*. 
+This is particularly useful in real-time scenarios, for instance when operating with `USBInput` or `UDPInput`
 
 ```python
 # Stream events from a DVS camera over USB
@@ -80,7 +88,7 @@ Please note the examples may require additional dependencies (such as [Norse](ht
 
 ### Example: real-time edge detection with spiking neural networks
 
-![](example/usb_edgedetection.gif)
+![](https://github.com/norse/aestream/raw/main/example/usb_edgedetection.gif)
 
 We stream events from a camera connected via USB and process them on a GPU in real-time using the [spiking neural network library, Norse](https://github.com/norse/norse) using fewer than 50 lines of Python.
 The left panel in the video shows the raw signal, while the middle and right panels show horizontal and vertical edge detection respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ requires = [
         "scikit-build",
         "cmake>=3.23",
         "wheel",
-        "nanobind",
+        "nanobind @ git+https://github.com/wjakob/nanobind",
         "ninja; platform_system!='Windows'"]
 build-backend = "setuptools.build_meta"

--- a/src/file/dat.cpp
+++ b/src/file/dat.cpp
@@ -1,6 +1,6 @@
 #include "dat.hpp"
 
-size_t dat_read_header(const shared_file_t &fp) {
+size_t dat_read_header(shared_file_t &fp) {
   size_t bytes_read = 0;
   uint8_t c, header_begins;
 
@@ -31,7 +31,7 @@ process_length:
   return (fileLength - bytes_read) / sizeof(int64_t);
 }
 
-std::tuple<AER::Event *, size_t> dat_read_n_events(const shared_file_t &fp,
+std::tuple<AER::Event *, size_t> dat_read_n_events(shared_file_t &fp,
                                                    const size_t &n_events) {
   const size_t buffer_size = BUFFER_SIZE > n_events ? n_events : BUFFER_SIZE;
 
@@ -66,7 +66,7 @@ std::tuple<AER::Event *, size_t> dat_read_n_events(const shared_file_t &fp,
 }
 
 Generator<AER::Event> dat_stream_events(const std::string filename) {
-  const shared_file_t &fp = open_file(filename);
+  shared_file_t fp = open_file(filename);
   const auto n_events = dat_read_header(fp);
   return dat_stream_events(fp, n_events);
 }

--- a/src/file/dat.hpp
+++ b/src/file/dat.hpp
@@ -19,9 +19,9 @@ struct DATEvent {
 
 inline AER::Event dat_decode_event(uint64_t data, size_t overflows);
 
-size_t dat_read_header(const shared_file_t &fp);
+size_t dat_read_header(shared_file_t &fp);
 
-std::tuple<AER::Event *, size_t> dat_read_n_events(const shared_file_t &fp,
+std::tuple<AER::Event *, size_t> dat_read_n_events(shared_file_t &fp,
                                                    const size_t &n_events);
 
 Generator<AER::Event> dat_stream_events(const std::string filename);

--- a/src/pybind/file.cpp
+++ b/src/pybind/file.cpp
@@ -91,13 +91,21 @@ bool FileInput::get_is_streaming() {
   return is_streaming.load() || is_nonempty.load();
 }
 
-// nb::tensor<nb::numpy, AER::Event> FileInput::events() {
-//   // const unique_file_t &fp = open_file(filename);
-//   // auto n_events = dat_read_header(fp);
-//   auto [event_array, n_events_read] = dat_read_n_events(fp, n_events);
 
-//   return nb::tensor<nb::numpy, AER::Event>(event_array, 1, n_events_read);
-// }
+std::vector<AER::Event> FileInput::load() {
+  const shared_file_t &fp = open_file(filename);
+  auto n_events = dat_read_header(fp);
+  auto [event_array, n_events_read] = dat_read_n_events(fp, n_events);
+
+  // return event_array;
+  // AER::Event* arr = new AER::Event[] { AER::Event( 0, 1, 2, true ), AER::Event( 0, 2, 3, true )};
+  // return nb::handle(PyMemoryView_FromMemory((char *) arr, 2, PyBUF_WRITE));
+  // return nb::handle(PyMemoryView_FromObject(arr));
+  // std::unique_ptr<AER::Event[]> p(event_array);
+  // return p;
+  std::span<AER::Event> data_span = std::span(event_array, n_events_read);
+  return std::vector<AER::Event>(data_span.begin(), data_span.end());
+}
 
 // py::array_t<AER::Event> FileInput::events_co() {
 //   AER::Event *event_array = (AER::Event *)malloc(n_events *

--- a/src/pybind/file.hpp
+++ b/src/pybind/file.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <span>
 
 #include "../aer.hpp"
 #include "../file/aedat4.hpp"
@@ -44,7 +45,7 @@ public:
 
   bool get_is_streaming();
 
-  // nb::tensor<nb::numpy, AER::Event> events();
+  std::vector<AER::Event> load();
 
   // py::array_t<AER::Event> events_co();
 

--- a/src/pybind/file.hpp
+++ b/src/pybind/file.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <algorithm>
-#include <span>
 
 #include "../aer.hpp"
 #include "../file/aedat4.hpp"
@@ -30,7 +29,7 @@ private:
 public:
   TensorBuffer buffer;
   py_size_t shape;
-  const shared_file_t &fp;
+  shared_file_t fp;
   Generator<AER::Event> generator;
   const std::string filename;
   size_t n_events;
@@ -45,7 +44,7 @@ public:
 
   bool get_is_streaming();
 
-  std::vector<AER::Event> load();
+  nb::ndarray<nb::numpy, uint8_t, nb::shape<1, nb::any>> load();
 
   // py::array_t<AER::Event> events_co();
 

--- a/src/pybind/iterator.cpp
+++ b/src/pybind/iterator.cpp
@@ -20,7 +20,7 @@ public:
   // Generator<AER::Event>::Iter begin() { return generator.begin(); }
   // std::default_sentinel_t end() { return generator.end(); }
 
-  nb::tensor<nb::numpy, AER::Event> next() {
+  nb::ndarray<nb::numpy, AER::Event> next() {
     if (done) {
       throw nb::stop_iteration();
     }
@@ -34,7 +34,7 @@ public:
       index++;
       if (index >= n_events_per_part) {
         const size_t s[] = {n_events_per_part};
-        return nb::tensor<nb::numpy, AER::Event>(array, 1, s);
+        return nb::ndarray<nb::numpy, AER::Event>(array, 1, s);
       }
     }
 
@@ -42,7 +42,7 @@ public:
       // return buffer_to_py_array(event_array, index);
       done = true;
       const size_t s[] = {index};
-      return nb::tensor<nb::numpy, AER::Event>(array, 1, s);
+      return nb::ndarray<nb::numpy, AER::Event>(array, 1, s);
     } else {
       throw nb::stop_iteration();
     }
@@ -101,7 +101,7 @@ public:
   // Generator<AER::Event>::Iter begin() { return generator.begin(); }
   // std::default_sentinel_t end() { return generator.end(); }
 
-  nb::tensor<nb::numpy, AER::Event> next() {
+  nb::ndarray<nb::numpy, AER::Event> next() {
     auto [event_array, n_events_read] =
         dat_read_n_events(file.fp, n_events_per_part);
 
@@ -109,6 +109,6 @@ public:
       throw nb::stop_iteration();
     }
 
-    return nb::tensor<nb::numpy, AER::Event>(event_array, 1, n_events_read);
+    return nb::ndarray<nb::numpy, AER::Event>(event_array, 1, n_events_read);
   }
 };

--- a/src/pybind/module.cpp
+++ b/src/pybind/module.cpp
@@ -15,18 +15,17 @@
 #endif
 
 namespace nb = nanobind;
+using EventVector = std::vector<AER::Event>;
 
 NB_MODULE(aestream_ext, m) {
-
   //   NB_NUMPY_DTYPE(AER::Event, timestamp, x, y, polarity);
 
   nb::class_<AER::Event>(m, "Event")
-      .def_property_readonly("timestamp",
-                             [](const AER::Event &e) { return e.timestamp; })
-      .def_property_readonly("x", [](const AER::Event &e) { return e.x; })
-      .def_property_readonly("y", [](const AER::Event &e) { return e.y; })
-      .def_property_readonly("polarity",
-                             [](const AER::Event &e) { return e.polarity; });
+      .def(nb::init<uint64_t, uint16_t, uint16_t, bool>())
+      .def_rw("timestamp", &AER::Event::timestamp)
+      .def_rw("x", &AER::Event::x)
+      .def_rw("y", &AER::Event::y)
+      .def_rw("polarity", &AER::Event::polarity);
 
   nb::class_<BufferPointer>(m, "BufferPointer")
       .def("to_numpy", &BufferPointer::to_numpy)
@@ -58,7 +57,7 @@ NB_MODULE(aestream_ext, m) {
       .def("__enter__", &FileInput::start_stream)
       .def("__exit__", &FileInput::stop_stream, nb::arg("a").none(),
            nb::arg("b").none(), nb::arg("c").none())
-      //  .def("events", &FileInput::events)
+      .def("load", &FileInput::load)
       //  .def("frames",
       //       [](nb::object fobj, size_t n_events_per_part) {
       //         return FrameIterator(fobj.cast<FileInput &>(),

--- a/src/pybind/module.cpp
+++ b/src/pybind/module.cpp
@@ -57,7 +57,7 @@ NB_MODULE(aestream_ext, m) {
       .def("__enter__", &FileInput::start_stream)
       .def("__exit__", &FileInput::stop_stream, nb::arg("a").none(),
            nb::arg("b").none(), nb::arg("c").none())
-      .def("load", &FileInput::load)
+      .def("load_all", &FileInput::load)
       //  .def("frames",
       //       [](nb::object fobj, size_t n_events_per_part) {
       //         return FrameIterator(fobj.cast<FileInput &>(),

--- a/src/pybind/tensor_buffer.hpp
+++ b/src/pybind/tensor_buffer.hpp
@@ -9,7 +9,8 @@
 #include "types.hpp"
 
 #include <nanobind/nanobind.h>
-#include <nanobind/tensor.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/unique_ptr.h>
 
 #ifdef USE_CUDA
 void index_increment_cuda(float *array, int *offset_pointer, size_t indices,
@@ -27,8 +28,8 @@ template <typename scalar_t> struct BufferDeleter {
   }
 };
 
-using tensor_numpy = nb::tensor<nb::numpy, float, nb::shape<2, nb::any>>;
-using tensor_torch = nb::tensor<nb::pytorch, float, nb::shape<2, nb::any>>;
+using tensor_numpy = nb::ndarray<nb::numpy, float, nb::shape<2, nb::any>>;
+using tensor_torch = nb::ndarray<nb::pytorch, float, nb::shape<2, nb::any>>;
 using buffer_t = std::unique_ptr<float[], BufferDeleter<float>>;
 using index_t = std::unique_ptr<int[], BufferDeleter<int>>;
 
@@ -39,9 +40,9 @@ struct BufferPointer {
   tensor_torch to_torch();
 
 private:
-  buffer_t data;
   std::string device;
   const std::vector<int64_t> &shape;
+  buffer_t data;
 };
 
 class TensorBuffer {

--- a/src/pybind/tensor_iterator.hpp
+++ b/src/pybind/tensor_iterator.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <nanobind/nanobind.h>
-#include <nanobind/tensor.h>
+#include <nanobind/ndarray.h>
 
 #include "../aer.hpp"
 #include "../generator.hpp"

--- a/src/pybind/test/test_file.py
+++ b/src/pybind/test/test_file.py
@@ -1,20 +1,24 @@
 import time
 import pytest
 
-import numpy
+import numpy as np
 from aestream import Event, FileInput
 
 from . import _has_cuda_torch, _has_torch
 
+class namespace:
+    pass
 
 def test_load_dat():
     f = FileInput("example/sample.dat", shape=(600, 400))
     buf = f.load()
+
     assert len(buf) == 539481
-    assert buf[0].timestamp == 0
-    assert buf[0].x == 237
-    assert buf[0].y == 121
-    assert buf[0].polarity == True
+    assert buf[0]["timestamp"] == 0
+    assert buf[0]["x"] == 237
+    assert buf[0]["y"] == 121
+    assert buf[0]["polarity"] == True
+
 
 def test_stream_dat():
     with FileInput(
@@ -32,10 +36,9 @@ def test_stream_dat():
                 import torch
                 assert isinstance(frame, torch.Tensor)
             else:
-                assert isinstance(frame, numpy.ndarray)
+                assert isinstance(frame, np.ndarray)
             events += frame.sum()
     assert events == 539136
-
 
 @pytest.mark.skipif(not _has_cuda_torch(), reason="Torch-gpu is not installed")
 def test_stream_dat_torch_cuda():

--- a/src/pybind/test/test_file.py
+++ b/src/pybind/test/test_file.py
@@ -2,12 +2,21 @@ import time
 import pytest
 
 import numpy
-from aestream import FileInput
+from aestream import Event, FileInput
 
 from . import _has_cuda_torch, _has_torch
 
 
-def test_read_dat():
+def test_load_dat():
+    f = FileInput("example/sample.dat", shape=(600, 400))
+    buf = f.load()
+    assert len(buf) == 539481
+    assert buf[0].timestamp == 0
+    assert buf[0].x == 237
+    assert buf[0].y == 121
+    assert buf[0].polarity == True
+
+def test_stream_dat():
     with FileInput(
         filename="example/sample.dat", shape=(600, 400), ignore_time=True
     ) as stream:
@@ -29,7 +38,7 @@ def test_read_dat():
 
 
 @pytest.mark.skipif(not _has_cuda_torch(), reason="Torch-gpu is not installed")
-def test_read_dat_torch_cuda():
+def test_stream_dat_torch_cuda():
     import torch
     with FileInput(
         filename="example/sample.dat", shape=(600, 400), ignore_time=True, device="cuda"
@@ -47,5 +56,4 @@ def test_read_dat_torch_cuda():
             events += frame.sum()
             time.sleep(0.1)
         events += stream.read().sum()
-    #assert events == 539136 TODO: Fix this
-    assert events >= 534000
+    assert events == 539136

--- a/src/pybind/types.hpp
+++ b/src/pybind/types.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <nanobind/nanobind.h>
-#include <nanobind/tensor.h>
+#include <nanobind/ndarray.h>
 
 #include <nanobind/stl/vector.h>
 


### PR DESCRIPTION
Re-introduced file reading primitives so `.dat` files can be read via `FileInput(...).load()`.

* Only .dat is supported for now
* I still haven't benchmarked the code, so I cannot guarantee there is no copying involved
* Note that this uses the master branch of nanobind, which will have to be changed when they release the next version